### PR TITLE
Fix typo on port parameter name expected

### DIFF
--- a/lib/fluent/plugin/out_riemann.rb
+++ b/lib/fluent/plugin/out_riemann.rb
@@ -4,7 +4,7 @@ class Fluent::RiemannOutput < Fluent::BufferedOutput
   Fluent::Plugin.register_output('riemann', self)
 
   config_param :host, :string, :default => '127.0.0.1'
-  config_param :post, :integer, :default => 5555
+  config_param :port, :integer, :default => 5555
   config_param :timeout, :integer, :default => 5
   config_param :protocol, :string, :default => 'tcp'
   config_param :service, :string, :default => nil


### PR DESCRIPTION
I'm using an unprivileged port and not the default one...
